### PR TITLE
Fixes over-indented code examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ A modern implementation of OSC for python2/3.
 Server (thread)
 
 ```python
-    from oscpy.server import OSCThreadServer
-    from time import sleep
+from oscpy.server import OSCThreadServer
+from time import sleep
 
-    def callback(values):
-        print("got values: {}".format(values))
+def callback(values):
+    print("got values: {}".format(values))
 
-    osc = OSCThreadServer()
-    sock = osc.listen(address='0.0.0.0', port=8000, default=True)
-    osc.bind(b'/address', callback)
-    sleep(1000)
-    osc.stop()
+osc = OSCThreadServer()
+sock = osc.listen(address='0.0.0.0', port=8000, default=True)
+osc.bind(b'/address', callback)
+sleep(1000)
+osc.stop()
 ```
 
 or you can use the decorator API.
@@ -47,77 +47,76 @@ or you can use the decorator API.
 Server (thread)
 
 ```python
-    from oscpy.server import OSCThreadServer
-    from time import sleep
+from oscpy.server import OSCThreadServer
+from time import sleep
 
-    osc = OSCThreadServer()
-    sock = osc.listen(address='0.0.0.0', port=8000, default=True)
+osc = OSCThreadServer()
+sock = osc.listen(address='0.0.0.0', port=8000, default=True)
 
-    @osc.address(b'/address')
-    def callback(values):
-        print("got values: {}".format(values))
+@osc.address(b'/address')
+def callback(values):
+    print("got values: {}".format(values))
 
-    sleep(1000)
-    osc.stop()
+sleep(1000)
+osc.stop()
 ```
 
 Servers are also client, in the sense they can send messages and answer to
 messages from other servers
 
 ```python
-    from oscpy.server import OSCThreadServer
-    from time import sleep
+from oscpy.server import OSCThreadServer
+from time import sleep
 
-    osc_1 = OSCThreadServer()
-    osc_1.listen(default=True)
+osc_1 = OSCThreadServer()
+osc_1.listen(default=True)
 
-    @osc_1.address(b'/ping')
-    def ping(*values):
-        print("ping called")
-        if True in values:
-            cont.append(True)
-        else:
-            osc_1.answer(b'/pong')
+@osc_1.address(b'/ping')
+def ping(*values):
+    print("ping called")
+    if True in values:
+        cont.append(True)
+    else:
+        osc_1.answer(b'/pong')
 
-    osc_2 = OSCThreadServer()
-    osc_2.listen(default=True)
+osc_2 = OSCThreadServer()
+osc_2.listen(default=True)
 
-    @osc_2.address(b'/pong')
-    def pong(*values):
-        print("pong called")
-        osc_2.answer(b'/ping', [True])
+@osc_2.address(b'/pong')
+def pong(*values):
+    print("pong called")
+    osc_2.answer(b'/ping', [True])
 
-    osc_2.send_message(b'/ping', [], *osc_1.getaddress())
+osc_2.send_message(b'/ping', [], *osc_1.getaddress())
 
-    timeout = time() + 1
-    while not cont:
-        if time() > timeout:
-            raise OSError('timeout while waiting for success message.')
+timeout = time() + 1
+while not cont:
+    if time() > timeout:
+        raise OSError('timeout while waiting for success message.')
 ```
 
 
 Server (async) (TODO!)
 
 ```python
-    from oscpy.server import OSCThreadServer
+from oscpy.server import OSCThreadServer
 
-    with OSCAsyncServer(port=8000) as OSC:
-        for address, values in OSC.listen():
-           if address == b'/example':
-                print("got {} on /example".format(values))
-           else:
-                print("unknown address {}".format(address))
+with OSCAsyncServer(port=8000) as OSC:
+    for address, values in OSC.listen():
+       if address == b'/example':
+            print("got {} on /example".format(values))
+       else:
+            print("unknown address {}".format(address))
 ```
 
 Client
 
 ```python
+from oscpy.client import OSCClient
 
-    from oscpy.client import OSCClient
-
-    osc = OSCClient(address, port)
-    for i in range(10):
-        osc.send_message(b'/ping', [i])
+osc = OSCClient(address, port)
+for i in range(10):
+    osc.send_message(b'/ping', [i])
 ```
 
 #### Unicode
@@ -129,21 +128,21 @@ them, so your callbacks will get unicode strings (unicode in python2, str in
 python3).
 
 ```python
-    osc = OSCThreadServer(encoding='utf8')
-    osc.listen(default=True)
+osc = OSCThreadServer(encoding='utf8')
+osc.listen(default=True)
 
-    values = []
+values = []
 
-    @osc.address(u'/encoded')
-    def encoded(*val):
-        for v in val:
-            assert not isinstance(v, bytes)
-        values.append(val)
+@osc.address(u'/encoded')
+def encoded(*val):
+    for v in val:
+        assert not isinstance(v, bytes)
+    values.append(val)
 
-    send_message(
-        u'/encoded',
-        [u'hello world', u'ééééé ààààà'],
-        *osc.getaddress(), encoding='utf8')
+send_message(
+    u'/encoded',
+    [u'hello world', u'ééééé ààààà'],
+    *osc.getaddress(), encoding='utf8')
 ```
 
 (`u` literals added here for clarity).


### PR DESCRIPTION
Code block doesn't require indent if introduced with triple backticks, see https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting