### PR TITLE
Feature/perfs stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ send_message(
 
 (`u` literals added here for clarity).
 
+#### CLI
+
+OSCPy provides an "oscli" util, to help with debugging:
+- `oscli dump` to listen for messages and dump them
+- `oscli send` to send messages or bundles to a server
+
+See `oscli -h` for more information.
+
 #### TODO
 
 - real support for timetag (currently only supports optionally

--- a/oscpy/__init__.py
+++ b/oscpy/__init__.py
@@ -1,1 +1,3 @@
 """See README.md for package information."""
+
+__version__ = '0.4.0-dev'

--- a/oscpy/cli.py
+++ b/oscpy/cli.py
@@ -1,0 +1,87 @@
+# coding: utf8
+"""OSCPy command line tools"""
+
+from argparse import ArgumentParser
+from time import sleep
+from sys import exit
+from ast import literal_eval
+
+from oscpy.client import send_message
+from oscpy.server import OSCThreadServer
+
+def _send(options):
+    def _parse(s):
+        try:
+            return literal_eval(s)
+        except:
+            return s
+
+    for i in range(options.repeat):
+        send_message(
+            options.address,
+            [_parse(x) for x in options.message],
+            options.host,
+            options.port,
+            safer=options.safer,
+            encoding=options.encoding,
+            encoding_errors=options.encoding_errors
+        )
+
+def _dump(options):
+    def dump(address, *values):
+        print('{}: {}'.format(address, values))
+
+    osc = OSCThreadServer(
+        encoding=options.encoding,
+        encoding_errors=options.encoding_errors,
+        default_handler=dump
+    )
+    osc.listen(
+        address=options.host,
+        port=options.port,
+        default=True
+    )
+    while True:
+        sleep(10)
+
+
+def main():
+    parser = ArgumentParser(description='OSCPy command line interface')
+
+    subparser = parser.add_subparsers()
+
+    send = subparser.add_parser('send', help='send an osc message to a server')
+    send.set_defaults(func=_send)
+    send.add_argument('--host', '-H', action='store', default='localhost',
+                      help='host (ip or name) to send message to.')
+    send.add_argument('--port', '-P', action='store', type=int, default='8000',
+                      help='port to send message to.')
+    send.add_argument('--encoding', '-e', action='store', default='utf-8',
+                      help='how to encode the strings')
+    send.add_argument('--encoding_errors', '-E', action='store', default='replace',
+                      help='how to treat string encoding issues')
+    send.add_argument('--safer', '-s', action='store_true',
+                      help='wait a little after sending message')
+    send.add_argument('--repeat', '-r', action='store', type=int, default=1,
+                      help='how many times to send the message')
+
+    send.add_argument('address', action='store',
+                      help='OSC address to send the message to.')
+    send.add_argument('message', nargs='*',
+                        help='content of the message, separated by spaces.')
+
+    dump = subparser.add_parser('dump', help='listen for messages and print them')
+    dump.set_defaults(func=_dump)
+    dump.add_argument('--host', '-H', action='store', default='localhost',
+                      help='host (ip or name) to send message to.')
+    dump.add_argument('--port', '-P', action='store', type=int, default='8000',
+                      help='port to send message to.')
+    dump.add_argument('--encoding', '-e', action='store', default='utf-8',
+                      help='how to encode the strings')
+    dump.add_argument('--encoding_errors', '-E', action='store', default='replace',
+                      help='how to treat string encoding issues')
+
+    # bridge = parser.add_parser('bridge', help='listen for messages and redirect them to a server')
+
+    options = parser.parse_args()
+    exit(options.func(options))

--- a/oscpy/cli.py
+++ b/oscpy/cli.py
@@ -9,6 +9,7 @@ from ast import literal_eval
 from oscpy.client import send_message
 from oscpy.server import OSCThreadServer
 
+
 def _send(options):
     def _parse(s):
         try:
@@ -26,6 +27,7 @@ def _send(options):
             encoding=options.encoding,
             encoding_errors=options.encoding_errors
         )
+
 
 def _dump(options):
     def dump(address, *values):

--- a/oscpy/parser.py
+++ b/oscpy/parser.py
@@ -185,7 +185,7 @@ def format_message(address, values, encoding='', encoding_errors='strict'):
 
         tags.append(tag)
         fmt.append(v_fmt)
-        count[tag] += 1
+        count[tag.decode('utf8')] += 1
 
     fmt = b''.join(fmt)
     tags = b''.join(tags + [NULL])

--- a/oscpy/parser.py
+++ b/oscpy/parser.py
@@ -24,10 +24,10 @@ import sys
 from collections import Counter
 from oscpy.stats import Stats
 
-if sys.version_info.major > 2:
+if sys.version_info.major > 2:  # pragma: no cover
     UNICODE = str
     izip = zip
-else:
+else:  # pragma: no cover
     UNICODE = unicode
     from itertools import izip
 

--- a/oscpy/server.py
+++ b/oscpy/server.py
@@ -391,7 +391,9 @@ class OSCThreadServer(object):
             ip_address,
             port,
             sock=sock,
-            safer=safer
+            safer=safer,
+            encoding=self.encoding,
+            encoding_errors=self.encoding_errors
         )
 
     def send_bundle(
@@ -412,7 +414,9 @@ class OSCThreadServer(object):
             ip_address,
             port,
             sock=sock,
-            safer=safer
+            safer=safer,
+            encoding=self.encoding,
+            encoding_errors=self.encoding_errors
         )
 
     def answer(
@@ -535,13 +539,29 @@ class OSCThreadServer(object):
         self.bind(b'/_oscpy/stats/sent', self._get_stats_sent, sock=sock)
 
     def _get_version(self, port, *args):
-        self.answer(b'/_oscpy/version/answer', (__version__, ), port=port)
+        self.answer(
+            b'/_oscpy/version/answer',
+            (__version__, ),
+            port=port
+        )
 
     def _get_routes(self, port, *args):
-        self.answer(b'/_oscpy/routes/answer', [a[1] for a in self.addresses], port=port)
+        self.answer(
+            b'/_oscpy/routes/answer',
+            [a[1] for a in self.addresses],
+            port=port
+        )
 
     def _get_stats_received(self, port, *args):
-        self.answer(b'/_oscpy/stats/received/answer', self.stats_received.to_tuple(), port=port)
+        self.answer(
+            b'/_oscpy/stats/received/answer',
+            self.stats_received.to_tuple(),
+            port=port
+        )
 
     def _get_stats_sent(self, port, *args):
-        self.answer(b'/_oscpy/stats/sent/answer', self.stats_sent.to_tuple(), port=port)
+        self.answer(
+            b'/_oscpy/stats/sent/answer',
+            self.stats_sent.to_tuple(),
+            port=port
+        )

--- a/oscpy/stats.py
+++ b/oscpy/stats.py
@@ -48,11 +48,22 @@ class Stats(object):
         )
 
     def __repr__(self):
-        return str(
-            dict(
-                calls=self.calls,
-                bytes=self.bytes,
-                params=self.params,
-                types=self.types
+        return 'Stats:\n' + '\n'.join(
+            '    {}:{}{}'.format(
+                k,
+                '' if isinstance(v, str) and v.startswith('\n') else ' ',
+                v
+            )
+            for k, v in (
+                ('calls', self.calls),
+                ('bytes', self.bytes),
+                ('params', self.params),
+                (
+                    'types',
+                    ''.join(
+                        '\n        {}: {}'.format(k, self.types[k])
+                        for k in sorted(self.types)
+                    )
+                )
             )
         )

--- a/oscpy/stats.py
+++ b/oscpy/stats.py
@@ -1,0 +1,58 @@
+"Simple utility class to gather stats about the volumes of data managed"
+
+from collections import Counter
+
+
+class Stats(object):
+    def __init__(self, calls=0, bytes=0, params=0, types=None, **kwargs):
+        self.calls = calls
+        self.bytes = bytes
+        self.params = params
+        self.types = types or Counter()
+        super(Stats, self).__init__(**kwargs)
+
+    def to_tuple(self):
+        types = self.types
+        keys = types.keys()
+        return (
+            self.calls,
+            self.bytes,
+            self.params,
+            ''.join(keys),
+        ) + tuple(types[k] for k in keys)
+
+    def __iadd__(self, other):
+        assert isinstance(other, Stats)
+        self.calls += other.calls
+        self.bytes += other.bytes
+        self.params += other.params
+        self.types += other.types
+        return self
+
+    def __add__(self, other):
+        assert isinstance(other, Stats)
+        return Stats(
+            calls=self.calls + other.calls,
+            bytes=self.bytes + other.bytes,
+            params=self.params + other.params,
+            types=self.types + other.types
+        )
+
+    def __eq__(self, other):
+        return other is self or (
+            isinstance(other, Stats)
+            and self.calls == self.calls
+            and self.bytes == self.bytes
+            and self.params == self.params
+            and self.types == other.types
+        )
+
+    def __repr__(self):
+        return str(
+            dict(
+                calls=self.calls,
+                bytes=self.bytes,
+                params=self.params,
+                types=self.types
+            )
+        )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from setuptools import setup, find_packages
 from io import open
 from os import path
 
+from oscpy import __version__
+
 here = path.abspath(path.dirname(__file__))
 
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -15,13 +17,13 @@ URL = 'https://github.com/kivy/oscpy'
 setup(
     name='oscpy',
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.0',
+    version=__version__,
     description='A modern and efficient OSC Client/Server implementation',
     long_description=long_description,
     url=URL,
     author='Gabriel Pettier',
-    author_email='gabriel.pettier@gmail.com',  # Optional
-    classifiers=[  # Optional
+    author_email='gabriel@kivy.org',
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Topic :: Multimedia :: Sound/Audio',
@@ -36,7 +38,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-    keywords='OSC network udp',  # Optional
+    keywords='OSC network udp',
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,9 @@ setup(
     },
     package_data={},
     data_files=[],
-    entry_points={},
+    entry_points={
+        'console_scripts': ['oscli=oscpy.cli:main'],
+    },
 
     project_urls={
         'Bug Reports': URL + '/issues',

--- a/tests/performances.py
+++ b/tests/performances.py
@@ -31,7 +31,7 @@ for i, pattern in enumerate(patterns):
 
     while time() < timeout:
         n += 1
-        p = format_message(b'/address', [b'test', 1, 1.2345])
+        p, s = format_message(b'/address', pattern)
 
     size = len(p) / 1000
     print(
@@ -48,6 +48,19 @@ for i, pattern in enumerate(patterns):
 
     print(
         f"parsed message {n} times ({n / DURATION}/s) "
+        f"({n * size / DURATION:.2f}MB/s)"
+    )
+
+
+    n = 0
+    timeout = time() + DURATION
+
+    while time() < timeout:
+        n += 1
+        read_message(format_message(b'/address', pattern)[0])
+
+    print(
+        f"round-trip {n} times ({n / DURATION}/s) "
         f"({n * size / DURATION:.2f}MB/s)"
     )
 
@@ -91,7 +104,7 @@ for family in 'unix', 'inet':
                 sent += 1
             sleep(10e-9)
 
-            size = len(format_message(b'/count', pattern)) / 1000.
+            size = len(format_message(b'/count', pattern)[0]) / 1000.
 
             print(
                 f"{i}: safe: {safer}\t",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,73 @@
+from textwrap import dedent
+from time import sleep
+from oscpy.cli import init_parser, main, _send, __dump
+from oscpy.client import send_message
+
+
+class Mock(object):
+    pass
+
+
+def test_init_parser():
+    parser = init_parser()
+
+
+def test__send(capsys):
+    options = Mock()
+    options.repeat = 2
+    options.host = 'localhost'
+    options.port = 12345
+    options.address = '/test'
+    options.safer = False
+    options.encoding = 'utf8'
+    options.encoding_errors = 'strict'
+    options.message = (1, 2, 3, 4, b"hello world")
+
+    _send(options)
+    captured = capsys.readouterr()
+    out = captured.out
+    assert out.startswith(dedent(
+        '''
+        Stats:
+            calls: 2
+            bytes: 88
+            params: 10
+            types:
+        '''
+    ).lstrip())
+    assert ' i: 8' in out
+    assert ' s: 2' in out
+
+
+def test___dump(capsys):
+    options = Mock()
+    options.repeat = 2
+    options.host = 'localhost'
+    options.port = 12345
+    options.address = b'/test'
+    options.safer = False
+    options.encoding = None
+    options.encoding_errors = 'strict'
+    options.message = (1, 2, 3, 4, b"hello world")
+
+    osc = __dump(options)
+    out = capsys.readouterr().out
+    assert out == ''
+
+    send_message(
+        options.address,
+        options.message,
+        options.host,
+        options.port,
+        safer=options.safer,
+        encoding=options.encoding,
+        encoding_errors=options.encoding_errors
+    )
+
+    sleep(0.1)
+    out, err = capsys.readouterr()
+    assert err == ''
+    lines = out.split('\n')
+    assert lines[0] == u"/test: 1, 2, 3, 4, hello world"
+
+    osc.stop()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,6 +150,14 @@ def test_read_broken_bundle():
         read_bundle(data)
 
 
+def test_read_broken_message():
+    # a message where ',' starting the list of tags has been replaced
+    # with \x00
+    s = b'/tmp\x00\x00\x00\x00\x00i\x00\x00\x00\x00\x00\x01'
+    with raises(ValueError):
+        read_message(s)
+
+
 def test_read_bundle():
     pad = padded(len('#bundle'))
     data = struct.pack('>%isQ' % pad, b'#bundle', 1)
@@ -194,6 +202,11 @@ def tests_format_message_null_terminated_address():
 def test_format_wrong_types():
     with raises(TypeError):
         format_message(b'/test', values=[u'test'])
+
+
+def test_format_unknown_type():
+    with raises(TypeError):
+        format_message(b'/test', values=[object])
 
 
 def test_format_bundle():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -212,9 +212,9 @@ def test_format_bundle():
     assert stats.calls == 2
     assert stats.bytes == 72
     assert stats.params == 6
-    assert stats.types[b'f'] == 3
-    assert stats.types[b'i'] == 2
-    assert stats.types[b's'] == 1
+    assert stats.types['f'] == 3
+    assert stats.types['i'] == 2
+    assert stats.types['s'] == 1
 
 
 def test_timetag():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -162,46 +162,6 @@ def test_bind_get_address_smart():
             raise OSError('timeout while waiting for success message.')
 
 
-def test_bind_get_address():
-    osc = OSCThreadServer()
-    sock = osc.listen()
-    port = sock.getsockname()[1]
-    cont = []
-
-    def success(address, *values):
-        assert address == b'/success'
-        cont.append(True)
-
-    osc.bind(b'/success', success, sock, get_address=True)
-
-    send_message(b'/success', [b'test', 1, 1.12345], 'localhost', port)
-
-    timeout = time() + 5
-    while not cont:
-        if time() > timeout:
-            raise OSError('timeout while waiting for success message.')
-
-
-def test_bind_get_address_smart():
-    osc = OSCThreadServer(advanced_matching=True)
-    sock = osc.listen()
-    port = sock.getsockname()[1]
-    cont = []
-
-    def success(address, *values):
-        assert address == b'/success/a'
-        cont.append(True)
-
-    osc.bind(b'/success/?', success, sock, get_address=True)
-
-    send_message(b'/success/a', [b'test', 1, 1.12345], 'localhost', port)
-
-    timeout = time() + 5
-    while not cont:
-        if time() > timeout:
-            raise OSError('timeout while waiting for success message.')
-
-
 def test_reuse_callback():
     osc = OSCThreadServer()
     sock = osc.listen()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,50 @@
+from collections import Counter
+from textwrap import dedent
+
+from oscpy.stats import Stats
+
+
+def test_create_stats():
+    stats = Stats(calls=1, bytes=2, params=3, types=Counter('abc'))
+    assert stats.calls == 1
+    assert stats.bytes == 2
+    assert stats.params == 3
+    assert stats.types['a'] == 1
+
+
+def test_add_stats():
+    stats = Stats(calls=1) + Stats(calls=3, bytes=2)
+    assert stats.calls == 4
+    assert stats.bytes == 2
+
+
+def test_compare_stats():
+    assert Stats(
+        calls=1, bytes=2, params=3, types=Counter('abc')
+    ) == Stats(
+        calls=1, bytes=2, params=3, types=Counter('abc')
+    )
+
+
+def test_to_tuple_stats():
+    tpl = Stats(
+        calls=1, bytes=2, params=3, types=Counter("import antigravity")
+    ).to_tuple()
+
+    assert tpl[:3] == (1, 2, 3,)
+    assert set(tpl[3]) == set('import antigravity')
+
+
+def test_repr_stats():
+    r = repr(Stats(calls=0, bytes=1, params=2, types=Counter('abc')))
+    assert r == dedent(
+    '''
+    Stats:
+        calls: 0
+        bytes: 1
+        params: 2
+        types:
+            a: 1
+            b: 1
+            c: 1
+    ''').strip()


### PR DESCRIPTION
Ok, this PR mixes a few different things, sorry about that
- perfs improvement of the message parsing, by avoiding unnecessary copies
- add oscli entrypoint with dump and send sub commands
- server info reporting through routes under /_oscpy/ (version, routes, stats)
- move version to oscpy/__init__.py for central availability
- version increment (to 0.4.0-dev)
- setup.py cleanup
- some "pragma: no cover" comments for parts that are specific to python versions and not coverable
- PEP8 improvements
