### PR TITLE
Initialized missing variables, added new test for server sending on different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Server (thread)
 from oscpy.server import OSCThreadServer
 from time import sleep
 
-def callback(values):
+def callback(*values):
     print("got values: {}".format(values))
 
 osc = OSCThreadServer()
@@ -70,7 +70,7 @@ osc = OSCThreadServer()
 sock = osc.listen(address='0.0.0.0', port=8000, default=True)
 
 @osc.address(b'/address')
-def callback(values):
+def callback(*values):
     print("got values: {}".format(values))
 
 sleep(1000)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Client
 ```python
 from oscpy.client import OSCClient
 
+address = "127.0.0.1"
+port = 8000
+
 osc = OSCClient(address, port)
 for i in range(10):
     osc.send_message(b'/ping', [i])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,7 @@ from os.path import exists
 from os import unlink
 
 from oscpy.server import OSCThreadServer, ServerClass
-from oscpy.client import send_message, send_bundle
+from oscpy.client import send_message, send_bundle, OSCClient
 from oscpy import __version__
 
 
@@ -878,3 +878,38 @@ def test_get_sender():
         if time() > timeout:
             raise OSError('timeout while waiting for success message.')
         sleep(10e-9)
+
+
+# TEST "test_server_different_port":
+
+checklist = []		# used for storing values received by callback_3000
+
+def callback_3000(*values):
+    checklist.append(values[0])
+
+def test_server_different_port():
+    # server, will be tested:
+    server_3000 = OSCThreadServer(encoding = 'utf8')
+    sock_3000 = server_3000.listen(address = '0.0.0.0', port = 3000, default = True)
+    server_3000.bind(b'/callback_3000', callback_3000)
+    # clients sending to different ports, used to test the server:
+    client_3000 = OSCClient(address = 'localhost', port = 3000, encoding='utf8')
+    
+    # server sends message to himself, should work:
+    server_3000.send_message(b'/callback_3000', ["a"], ip_address = 'localhost', port = 3000)
+    sleep(0.05)
+    # client sends message to server, will be received properly:
+    client_3000.send_message(b'/callback_3000', ["b"])
+    sleep(0.05)
+    # sever sends message on different port, might crash the server on windows:
+    server_3000.send_message(b'/callback_3000', ["nobody is going to receive this"], ip_address = 'localhost', port = 3001)
+    sleep(0.05)
+    # client sends message to server again. if server is dead, message will not be received:
+    client_3000.send_message(b'/callback_3000', ["c"])
+    sleep(0.1)		# give time to finish transmissions
+    
+    # if 'c' is missing in the received checklist, the server thread crashed and could not recieve the last message from the client:
+    assert checklist == ['a', 'b', 'c']
+    
+    server_3000.stop()	# clean up 
+


### PR DESCRIPTION
In the 'client' example, variables 'address' and 'port' where misssing. Initialized.
Additionally, added two missing '*' in functions args.
Most of all, there is a new test: If a server sends something on a port different than its listening port, this might crash the listening thread on Windows machines. This now is checked.