### PR TITLE
fix #48

### DIFF
--- a/oscpy/server.py
+++ b/oscpy/server.py
@@ -243,7 +243,6 @@ class OSCThreadServer(object):
         else:
             addr = (address, port)
         sock.bind(addr)
-        # sock.setblocking(0)
         self.sockets.append(sock)
         if default and not self.default_socket:
             self.default_socket = sock
@@ -333,7 +332,11 @@ class OSCThreadServer(object):
                     continue
 
             for sender_socket in read:
-                data, sender = sender_socket.recvfrom(65535)
+                try:
+                    data, sender = sender_socket.recvfrom(65535)
+                except ConnectionResetError:
+                    continue
+
                 for address, tags, values, offset in read_packet(
                     data, drop_late=drop_late, encoding=self.encoding,
                     encoding_errors=self.encoding_errors

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -889,7 +889,7 @@ def test_server_different_port():
 
     # server, will be tested:
     server_3000 = OSCThreadServer(encoding='utf8')
-    sock_3000 = server_3000.listen( address='0.0.0.0', port=3000, default=True)
+    sock_3000 = server_3000.listen(address='0.0.0.0', port=3000, default=True)
     server_3000.bind(b'/callback_3000', callback_3000)
 
     # clients sending to different ports, used to test the server:


### PR DESCRIPTION
windows doesn't like when messages are sent and nobody reads them
it seems to punish innocent sockets that listened on completly unrelated
ports. Since it resets the connections, we just ignore the message in
this situation, and try reading again. This seems to fix the issue.

@Heideachim this should fix your issue.