### PR TITLE
Add ordered termination of server and protection against callback errors

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -90,6 +90,15 @@ def test_stop_all():
     osc.stop_all()
 
 
+def test_terminate_server():
+    osc = OSCThreadServer()
+    assert not osc.join_server(timeout=0.1)
+    assert osc._thread.is_alive()
+    osc.terminate_server()
+    assert osc.join_server(timeout=0.1)
+    assert not osc._thread.is_alive()
+
+
 def test_send_message_without_socket():
     osc = OSCThreadServer()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
This PR lets the server be terminated in an ordered manner (in case the tasks are sensitive), and lets the server catch/log callback errors instead of silently crashing.

I've put this last option as ON by default, since I can't easily see a case where silently crashing on error would be really wanted.

All tests and coverage look OK to me (on python2.7).