### PR TITLE
Accept malformed messages

### DIFF
--- a/oscpy/server.py
+++ b/oscpy/server.py
@@ -60,7 +60,8 @@ class OSCThreadServer(object):
 
     def __init__(
         self, drop_late_bundles=False, timeout=0.01, advanced_matching=False,
-        encoding='', encoding_errors='strict', default_handler=None, intercept_errors=True
+        encoding='', encoding_errors='strict', default_handler=None, intercept_errors=True,
+        validate_message_address=True
     ):
         """Create an OSCThreadServer.
 
@@ -86,6 +87,10 @@ class OSCThreadServer(object):
         - `intercept_errors`, if True, means that exception raised by
           callbacks will be intercepted and logged. If False, the handler
           thread will terminate mostly silently on such exceptions.
+        - `validate_message_address`, if True, require received messages
+          to have an address beginning with the specified OSC address
+          pattern of '/'. Set to False to accept messages from
+          implementations that ignore the address pattern specification.
         """
         self._must_loop = True
         self._termination_event = Event()
@@ -100,6 +105,7 @@ class OSCThreadServer(object):
         self.encoding_errors = encoding_errors
         self.default_handler = default_handler
         self.intercept_errors = intercept_errors
+        self.validate_message_address = validate_message_address
 
         self.stats_received = Stats()
         self.stats_sent = Stats()
@@ -386,7 +392,8 @@ class OSCThreadServer(object):
                 try:
                     for address, tags, values, offset in read_packet(
                         data, drop_late=drop_late, encoding=self.encoding,
-                        encoding_errors=self.encoding_errors
+                        encoding_errors=self.encoding_errors,
+                        validate_message_address=self.validate_message_address
                     ):
                         stats.calls += 1
                         stats.bytes += offset

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -973,3 +973,25 @@ def test_server_different_port():
     assert checklist == ['a', 'b', 'c']
 
     server_3000.stop()	# clean up
+
+
+def test_accept_malformed_messages():
+    osc = OSCThreadServer(accept_malformed_messages=True)
+    osc.listen(default=True)
+
+    received = []
+
+    @osc.address(b'malformed')
+    def malformed(*val):
+        received.append(val[0])
+
+    send_message(
+        b'malformed',
+        [ b'message' ],
+        *osc.getaddress())
+
+    timeout = time() + 2
+    while not received:
+        if time() > timeout:
+            raise OSError('timeout while waiting for success message.')
+        sleep(10e-9)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -975,8 +975,8 @@ def test_server_different_port():
     server_3000.stop()	# clean up
 
 
-def test_accept_malformed_messages():
-    osc = OSCThreadServer(accept_malformed_messages=True)
+def test_validate_message_address_disabled():
+    osc = OSCThreadServer(validate_message_address=False)
     osc.listen(default=True)
 
     received = []


### PR DESCRIPTION
Allows optional acceptance of malformed messages that have an address beginning with something other than '/'. Messages are still required to begin with '/' by default to enforce the OSC specification.

Required to support Midas M32/Behringer X32 OSC implementation that sends messages with an address of 'node' or beginning with 'meters/'.