### PR TITLE
Awaited send message

### DIFF
--- a/oscpy/server/curio_server.py
+++ b/oscpy/server/curio_server.py
@@ -5,6 +5,7 @@ import os
 
 from curio import TaskGroup, socket
 from oscpy.server import OSCBaseServer, UDP_MAX_SIZE
+from oscpy.client import async_send_bundle, async_send_message
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -22,6 +23,52 @@ class OSCCurioServer(OSCBaseServer):
         sock = socket.socket(family, socket.SOCK_DGRAM)
         sock.bind(addr)
         return sock
+
+    async def send_message(self,
+        osc_address, values, ip_address, port, sock=None, safer=False,
+        encoding='', encoding_errors='strict'
+    ):
+        if not sock and self.default_socket:
+            sock = self.default_socket
+        elif not sock:
+            raise RuntimeError('no default socket yet and no socket provided')
+        stats = await async_send_message(
+            osc_address,
+            values,
+            ip_address,
+            port,
+            sock=sock,
+            safer=safer,
+            encoding=self.encoding,
+            encoding_errors=self.encoding_errors
+        )
+        self.stats_sent += stats
+        return stats
+
+    async def send_bundle(
+        self, messages, ip_address, port, timetag=None, sock=None, safer=False
+    ):
+        """Shortcut to the client's `send_bundle` method.
+
+        Use the `default_socket` of the server by default.
+        See `client.send_bundle` for more info about the parameters.
+        """
+        if not sock and self.default_socket:
+            sock = self.default_socket
+        elif not sock:
+            raise RuntimeError('no default socket yet and no socket provided')
+
+        stats = await async_send_bundle(
+            messages,
+            ip_address,
+            port,
+            sock=sock,
+            safer=safer,
+            encoding=self.encoding,
+            encoding_errors=self.encoding_errors
+        )
+        self.stats_sent += stats
+        return stats
 
     async def _listen(self, sock):
         async with TaskGroup(wait=all) as g:


### PR DESCRIPTION
Add awaited send_message functions for curio and trio implementations
    
In order to send a message over an awaited server socket (i.e. when you need external servers to reply to your listening server socket) the sock.sendto call needs to be awaited as well.
    
This commit adds async/await versions of the send_message and send_bundle functions that are called by the OSCCurioServer and OSCTrioServer send_message and send_bundle methods.

Strictly speaking, the async/await functions would probably not be used directly from the client module, so maybe there is a better place to put them. I tried to find ways to reduce code duplication as much as possible.