### PR TITLE
Modify blob parser and test_blob to address issue #72.

### DIFF
--- a/oscpy/parser.py
+++ b/oscpy/parser.py
@@ -91,10 +91,10 @@ def parse_string(value, offset=0, encoding='', encoding_errors='strict'):
 
 def parse_blob(value, offset=0, **kwargs):
     """Return a blob from offset in value."""
-    size = calcsize('>i')
-    length = unpack_from('>i', value, offset)[0]
-    data = unpack_from('>%iQ' % length, value, offset + size)
-    return data, padded(length, 8)
+    size = INT.size
+    length = INT.unpack_from(value, offset)[0]
+    data = unpack_from('>%is' % length, value, offset + size)[0]
+    return data, padded(length)
 
 
 def parse_midi(value, offset=0, **kwargs):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -108,10 +108,10 @@ def test_parse_string_encoded():
 
 def test_parse_blob():
     length = 10
-    data = tuple(range(length))
-    pad = padded(length, 8)
-    fmt = '>i%iQ' % pad
-    s = struct.pack(fmt, length, *(data + (pad - length) * (0, )))
+    data = bytes(range(length))
+    pad = padded(length)
+    fmt = '>i%is' % pad
+    s = struct.pack(fmt, length, data + bytes(pad - length))
     result = parse(b'b', s)[0]
     assert result == data
 


### PR DESCRIPTION
Hey @tshirtman,

I changed the format for binary blobs to `>%is`.
I used `s` instead of `p` or `c` because it is char[] without length limitation.
According to the [struct documentation](https://docs.python.org/3/library/struct.html) `p` has a maximum length of 255 characters and `c` is single characters.
I believe using `s` is the best option here.

Before you used `Q` which has a byte length of 8, since this is no longer necessary I removed the length argument from the call to `padding` (use the default length of 4).

This covers and works with my original use case sending data from tinyosc (see issue #72).
However, sending blobs via send_message still uses single characters due to the way format_message works.
I don't know if that needs to change, but I believe the issue of not being able to read blob data is addressed by the changes here.

Looking forward to your reply and hope the changes make it into oscpy 😄