### PR TITLE
Add free threaded Python 3.14t to the testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,29 +1,34 @@
-on: push
+on:
+  push:
+  pull_request:
+
 name: on push
 jobs:
   Tests:
     name: base
     strategy:
+      fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.11']
-        # os: ['ubuntu-latest', 'windows-latest', 'macOs-latest']
-        os: ['ubuntu-latest', 'windows-latest']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11']
+        os: ['ubuntu-latest', 'windows-latest']  # , 'macos-latest']
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master
-    - name: Setup python
+    - name: Setup Python ${{ matrix.python }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
         allow-prereleases: true
     - name: prepare
-      run: pip install -U setuptools wheel
+      run: pip install --upgrade setuptools wheel
     - name: install
       run: pip install .[dev,ci]
     - name: test
       run: python -m pytest --reruns 5 tests/ --cov oscpy/ --cov-branch
+      timeout-minutes: 15
     - name: coveralls
       run: python -m coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

Python 3.14 passes on both Ubuntu and Windows
Python 3.14t fails on both Ubuntu and Windows

PyPy 3.10 passes on both Ubuntu and Windows
PyPy 3.11 passes on Ubuntu but fails on Windows